### PR TITLE
Implement partial rebuilds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "flexsearch": "0.7.43",
         "github-slugger": "^2.0.0",
         "globby": "^14.0.0",
-        "graphology": "^0.25.4",
         "gray-matter": "^4.0.3",
         "hast-util-to-html": "^9.0.0",
         "hast-util-to-jsx-runtime": "^2.3.0",
@@ -2112,14 +2111,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -2327,24 +2318,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/graphology": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/graphology/-/graphology-0.25.4.tgz",
-      "integrity": "sha512-33g0Ol9nkWdD6ulw687viS8YJQBxqG5LWII6FI6nul0pq6iM2t5EKquOTFDbyTblRB3O9I+7KX4xI8u5ffekAQ==",
-      "dependencies": {
-        "events": "^3.3.0",
-        "obliterator": "^2.0.2"
-      },
-      "peerDependencies": {
-        "graphology-types": ">=0.24.0"
-      }
-    },
-    "node_modules/graphology-types": {
-      "version": "0.24.7",
-      "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.24.7.tgz",
-      "integrity": "sha512-tdcqOOpwArNjEr0gNQKCXwaNCWnQJrog14nJNQPeemcLnXQUUGrsCWpWkVKt46zLjcS6/KGoayeJfHHyPDlvwA==",
-      "peer": true
     },
     "node_modules/gray-matter": {
       "version": "4.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "flexsearch": "0.7.43",
         "github-slugger": "^2.0.0",
         "globby": "^14.0.0",
+        "graphology": "^0.25.4",
         "gray-matter": "^4.0.3",
         "hast-util-to-html": "^9.0.0",
         "hast-util-to-jsx-runtime": "^2.3.0",
@@ -2111,6 +2112,14 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -2318,6 +2327,24 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/graphology": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/graphology/-/graphology-0.25.4.tgz",
+      "integrity": "sha512-33g0Ol9nkWdD6ulw687viS8YJQBxqG5LWII6FI6nul0pq6iM2t5EKquOTFDbyTblRB3O9I+7KX4xI8u5ffekAQ==",
+      "dependencies": {
+        "events": "^3.3.0",
+        "obliterator": "^2.0.2"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.24.0"
+      }
+    },
+    "node_modules/graphology-types": {
+      "version": "0.24.7",
+      "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.24.7.tgz",
+      "integrity": "sha512-tdcqOOpwArNjEr0gNQKCXwaNCWnQJrog14nJNQPeemcLnXQUUGrsCWpWkVKt46zLjcS6/KGoayeJfHHyPDlvwA==",
+      "peer": true
     },
     "node_modules/gray-matter": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "flexsearch": "0.7.43",
     "github-slugger": "^2.0.0",
     "globby": "^14.0.0",
-    "graphology": "^0.25.4",
     "gray-matter": "^4.0.3",
     "hast-util-to-html": "^9.0.0",
     "hast-util-to-jsx-runtime": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "docs": "npx quartz build --serve -d docs",
     "check": "tsc --noEmit && npx prettier . --check",
     "format": "npx prettier . --write",
-    "test": "tsx ./quartz/util/path.test.ts",
+    "test": "tsx ./quartz/util/path.test.ts && tsx ./quartz/depgraph.test.ts",
     "profile": "0x -D prof ./quartz/bootstrap-cli.mjs build --concurrency=1"
   },
   "engines": {
@@ -46,6 +46,7 @@
     "flexsearch": "0.7.43",
     "github-slugger": "^2.0.0",
     "globby": "^14.0.0",
+    "graphology": "^0.25.4",
     "gray-matter": "^4.0.3",
     "hast-util-to-html": "^9.0.0",
     "hast-util-to-jsx-runtime": "^2.3.0",

--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -31,7 +31,7 @@ type BuildData = {
   toRebuild: Set<FilePath>
   toRemove: Set<FilePath>
   lastBuildMs: number
-  depGraphs: Record<string, DepGraph<string>>
+  depGraphs: Record<string, DepGraph<FilePath>>
 }
 
 type FileEvent = "add" | "change" | "delete"
@@ -74,7 +74,7 @@ async function buildQuartz(argv: Argv, mut: Mutex, clientRefresh: () => void) {
   const parsedFiles = await parseMarkdown(ctx, filePaths)
   const filteredContent = filterContent(ctx, parsedFiles)
 
-  const depGraphs: Record<string, DepGraph<string>> = {}
+  const depGraphs: Record<string, DepGraph<FilePath>> = {}
   const staticResources = getStaticResourcesFromPlugins(ctx)
   for (const emitter of cfg.plugins.emitters) {
     const emitterGraph = await emitter.getDependencyGraph(ctx, filteredContent, staticResources)
@@ -96,7 +96,7 @@ async function startServing(
   mut: Mutex,
   initialContent: ProcessedContent[],
   clientRefresh: () => void,
-  depGraphs: Record<string, DepGraph<string>>, // emitter name: dep graph
+  depGraphs: Record<string, DepGraph<FilePath>>, // emitter name: dep graph
 ) {
   const { argv } = ctx
 

--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -184,7 +184,7 @@ async function partialRebuildFromEntrypoint(
       // update the dep graph by asking all emitters whether they depend on this file
       for (const emitter of cfg.plugins.emitters) {
         const emitterGraph = await emitter.getDependencyGraph(ctx, processedFiles, staticResources)
-        depGraphs[emitter.name].mergeEdgesForNode(emitterGraph, fp)
+        depGraphs[emitter.name].updateIncomingEdgesForNode(emitterGraph, fp)
       }
       break
     case "change":
@@ -202,7 +202,7 @@ async function partialRebuildFromEntrypoint(
             staticResources,
           )
           // merge the new dependencies into the dep graph
-          depGraphs[emitter.name].mergeEdgesForNode(emitterGraph, fp)
+          depGraphs[emitter.name].updateIncomingEdgesForNode(emitterGraph, fp)
         }
       }
       break

--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -31,7 +31,7 @@ type BuildData = {
   toRebuild: Set<FilePath>
   toRemove: Set<FilePath>
   lastBuildMs: number
-  depGraphs: Record<string, DepGraph>
+  depGraphs: Record<string, DepGraph<string>>
 }
 
 type FileEvent = "add" | "change" | "delete"
@@ -74,7 +74,7 @@ async function buildQuartz(argv: Argv, mut: Mutex, clientRefresh: () => void) {
   const parsedFiles = await parseMarkdown(ctx, filePaths)
   const filteredContent = filterContent(ctx, parsedFiles)
 
-  const depGraphs: Record<string, DepGraph> = {}
+  const depGraphs: Record<string, DepGraph<string>> = {}
   const staticResources = getStaticResourcesFromPlugins(ctx)
   for (const emitter of cfg.plugins.emitters) {
     const emitterGraph = await emitter.getDependencyGraph(ctx, filteredContent, staticResources)
@@ -96,7 +96,7 @@ async function startServing(
   mut: Mutex,
   initialContent: ProcessedContent[],
   clientRefresh: () => void,
-  depGraphs: Record<string, DepGraph>, // emitter name: dep graph
+  depGraphs: Record<string, DepGraph<string>>, // emitter name: dep graph
 ) {
   const { argv } = ctx
 
@@ -224,7 +224,7 @@ async function partialRebuild(
       //
       // if a.md changes, we need to re-emit contentIndex.json,
       // and supply [a.md, b.md] to the emitter
-      const upstreams = [...depGraph.getUpstreamsOfDownstreamLeafNodes(fp)] as FilePath[]
+      const upstreams = [...depGraph.getLeafNodeAncestors(fp)] as FilePath[]
 
       if (action == "delete" && upstreams.length === 1) {
         // if there's only one upstream, the destination is solely dependent on this file

--- a/quartz/cli/args.js
+++ b/quartz/cli/args.js
@@ -71,6 +71,11 @@ export const BuildArgv = {
     default: false,
     describe: "run a local server to live-preview your Quartz",
   },
+  fastRebuild: {
+    boolean: true,
+    default: false,
+    describe: "[experimental] rebuild only the changed files",
+  },
   baseDir: {
     string: true,
     default: "",

--- a/quartz/depgraph.test.ts
+++ b/quartz/depgraph.test.ts
@@ -14,62 +14,79 @@ describe("DepGraph", () => {
     assert.deepStrictEqual(graph.getLeafNodes("D"), new Set(["C"]))
   })
 
-  test("getLeafNodeAncestors", () => {
-    const graph = new DepGraph<string>()
-    graph.addEdge("A", "B")
-    graph.addEdge("B", "C")
-    graph.addEdge("D", "B")
-    assert.deepStrictEqual(graph.getLeafNodeAncestors("A"), new Set(["A", "B", "D"]))
-    assert.deepStrictEqual(graph.getLeafNodeAncestors("B"), new Set(["A", "B", "D"]))
-    assert.deepStrictEqual(graph.getLeafNodeAncestors("C"), new Set(["A", "B", "D"]))
-    assert.deepStrictEqual(graph.getLeafNodeAncestors("D"), new Set(["A", "B", "D"]))
-  })
-
-  describe("mergeEdgesForNode", () => {
-    test("merges when node exists", () => {
-      // A -> B -> C
+  describe("getLeafNodeAncestors", () => {
+    test("gets correct ancestors in a graph without cycles", () => {
       const graph = new DepGraph<string>()
       graph.addEdge("A", "B")
       graph.addEdge("B", "C")
+      graph.addEdge("D", "B")
+      assert.deepStrictEqual(graph.getLeafNodeAncestors("A"), new Set(["A", "B", "D"]))
+      assert.deepStrictEqual(graph.getLeafNodeAncestors("B"), new Set(["A", "B", "D"]))
+      assert.deepStrictEqual(graph.getLeafNodeAncestors("C"), new Set(["A", "B", "D"]))
+      assert.deepStrictEqual(graph.getLeafNodeAncestors("D"), new Set(["A", "B", "D"]))
+    })
 
-      // B -> D
+    test("gets correct ancestors in a graph with cycles", () => {
+      const graph = new DepGraph<string>()
+      graph.addEdge("A", "B")
+      graph.addEdge("B", "C")
+      graph.addEdge("C", "A")
+      graph.addEdge("C", "D")
+      assert.deepStrictEqual(graph.getLeafNodeAncestors("A"), new Set(["A", "B", "C"]))
+      assert.deepStrictEqual(graph.getLeafNodeAncestors("B"), new Set(["A", "B", "C"]))
+      assert.deepStrictEqual(graph.getLeafNodeAncestors("C"), new Set(["A", "B", "C"]))
+      assert.deepStrictEqual(graph.getLeafNodeAncestors("D"), new Set(["A", "B", "C"]))
+    })
+  })
+
+  describe("updateIncomingEdgesForNode", () => {
+    test("merges when node exists", () => {
+      // A.md -> B.md -> B.html
+      const graph = new DepGraph<string>()
+      graph.addEdge("A.md", "B.md")
+      graph.addEdge("B.md", "B.html")
+
+      // B.md is edited so it removes the A.md transclusion
+      // and adds C.md transclusion
+      // C.md -> B.md
       const other = new DepGraph<string>()
-      other.addEdge("B", "D")
+      other.addEdge("C.md", "B.md")
+      other.addEdge("B.md", "B.html")
 
-      // B -> C removed, B -> D added
-      // A -> B -> D
-      graph.mergeEdgesForNode(other, "B")
+      // A.md -> B.md removed, C.md -> B.md added
+      // C.md -> B.md -> B.html
+      graph.updateIncomingEdgesForNode(other, "B.md")
 
       const expected = {
-        nodes: ["A", "B", "C", "D"],
+        nodes: ["A.md", "B.md", "B.html", "C.md"],
         edges: [
-          ["A", "B"],
-          ["B", "D"],
+          ["B.md", "B.html"],
+          ["C.md", "B.md"],
         ],
       }
-
-      console.log(graph.export())
 
       assert.deepStrictEqual(graph.export(), expected)
     })
 
     test("adds node if it does not exist", () => {
-      // A -> B
+      // A.md -> B.md
       const graph = new DepGraph<string>()
-      graph.addEdge("A", "B")
+      graph.addEdge("A.md", "B.md")
 
-      // C -> D
+      // Add a new file C.md that transcludes B.md
+      // B.md -> C.md
       const other = new DepGraph<string>()
-      other.addEdge("C", "D")
+      other.addEdge("B.md", "C.md")
 
-      // A -> B, C -> D
-      graph.mergeEdgesForNode(other, "C")
+      // B.md -> C.md added
+      // A.md -> B.md -> C.md
+      graph.updateIncomingEdgesForNode(other, "C.md")
 
       const expected = {
-        nodes: ["A", "B", "C", "D"],
+        nodes: ["A.md", "B.md", "C.md"],
         edges: [
-          ["A", "B"],
-          ["C", "D"],
+          ["A.md", "B.md"],
+          ["B.md", "C.md"],
         ],
       }
 

--- a/quartz/depgraph.test.ts
+++ b/quartz/depgraph.test.ts
@@ -3,37 +3,37 @@ import DepGraph from "./depgraph"
 import assert from "node:assert"
 
 describe("DepGraph", () => {
-  test("getDownstreamLeafNodes", () => {
-    const graph = new DepGraph()
+  test("getLeafNodes", () => {
+    const graph = new DepGraph<string>()
     graph.addEdge("A", "B")
     graph.addEdge("B", "C")
     graph.addEdge("D", "C")
-    assert.deepStrictEqual(graph.getDownstreamLeafNodes("A"), new Set(["C"]))
-    assert.deepStrictEqual(graph.getDownstreamLeafNodes("B"), new Set(["C"]))
-    assert.deepStrictEqual(graph.getDownstreamLeafNodes("C"), new Set(["C"]))
-    assert.deepStrictEqual(graph.getDownstreamLeafNodes("D"), new Set(["C"]))
+    assert.deepStrictEqual(graph.getLeafNodes("A"), new Set(["C"]))
+    assert.deepStrictEqual(graph.getLeafNodes("B"), new Set(["C"]))
+    assert.deepStrictEqual(graph.getLeafNodes("C"), new Set(["C"]))
+    assert.deepStrictEqual(graph.getLeafNodes("D"), new Set(["C"]))
   })
 
-  test("getUpstreamsOfDownstreamLeafNodes", () => {
-    const graph = new DepGraph()
+  test("getLeafNodeAncestors", () => {
+    const graph = new DepGraph<string>()
     graph.addEdge("A", "B")
     graph.addEdge("B", "C")
     graph.addEdge("D", "B")
-    assert.deepStrictEqual(graph.getUpstreamsOfDownstreamLeafNodes("A"), new Set(["A", "B", "D"]))
-    assert.deepStrictEqual(graph.getUpstreamsOfDownstreamLeafNodes("B"), new Set(["A", "B", "D"]))
-    assert.deepStrictEqual(graph.getUpstreamsOfDownstreamLeafNodes("C"), new Set(["A", "B", "D"]))
-    assert.deepStrictEqual(graph.getUpstreamsOfDownstreamLeafNodes("D"), new Set(["A", "B", "D"]))
+    assert.deepStrictEqual(graph.getLeafNodeAncestors("A"), new Set(["A", "B", "D"]))
+    assert.deepStrictEqual(graph.getLeafNodeAncestors("B"), new Set(["A", "B", "D"]))
+    assert.deepStrictEqual(graph.getLeafNodeAncestors("C"), new Set(["A", "B", "D"]))
+    assert.deepStrictEqual(graph.getLeafNodeAncestors("D"), new Set(["A", "B", "D"]))
   })
 
   describe("mergeEdgesForNode", () => {
     test("merges when node exists", () => {
       // A -> B -> C
-      const graph = new DepGraph()
+      const graph = new DepGraph<string>()
       graph.addEdge("A", "B")
       graph.addEdge("B", "C")
 
       // B -> D
-      const other = new DepGraph()
+      const other = new DepGraph<string>()
       other.addEdge("B", "D")
 
       // B -> C removed, B -> D added
@@ -41,41 +41,39 @@ describe("DepGraph", () => {
       graph.mergeEdgesForNode(other, "B")
 
       const expected = {
-        options: { type: "directed", multi: false, allowSelfLoops: false },
-        attributes: {},
-        nodes: [{ key: "A" }, { key: "B" }, { key: "C" }, { key: "D" }],
+        nodes: ["A", "B", "C", "D"],
         edges: [
-          { key: "A -> B", source: "A", target: "B" },
-          { key: "B -> D", source: "B", target: "D" },
+          ["A", "B"],
+          ["B", "D"],
         ],
       }
 
-      assert.deepStrictEqual(graph.graph.toJSON(), expected)
+      console.log(graph.export())
+
+      assert.deepStrictEqual(graph.export(), expected)
     })
 
     test("adds node if it does not exist", () => {
       // A -> B
-      const graph = new DepGraph()
+      const graph = new DepGraph<string>()
       graph.addEdge("A", "B")
 
       // C -> D
-      const other = new DepGraph()
+      const other = new DepGraph<string>()
       other.addEdge("C", "D")
 
       // A -> B, C -> D
       graph.mergeEdgesForNode(other, "C")
 
       const expected = {
-        options: { type: "directed", multi: false, allowSelfLoops: false },
-        attributes: {},
-        nodes: [{ key: "A" }, { key: "B" }, { key: "C" }, { key: "D" }],
+        nodes: ["A", "B", "C", "D"],
         edges: [
-          { key: "A -> B", source: "A", target: "B" },
-          { key: "C -> D", source: "C", target: "D" },
+          ["A", "B"],
+          ["C", "D"],
         ],
       }
 
-      assert.deepStrictEqual(graph.graph.toJSON(), expected)
+      assert.deepStrictEqual(graph.export(), expected)
     })
   })
 })

--- a/quartz/depgraph.test.ts
+++ b/quartz/depgraph.test.ts
@@ -1,0 +1,81 @@
+import test, { describe } from "node:test"
+import DepGraph from "./depgraph"
+import assert from "node:assert"
+
+describe("DepGraph", () => {
+  test("getDownstreamLeafNodes", () => {
+    const graph = new DepGraph()
+    graph.addEdge("A", "B")
+    graph.addEdge("B", "C")
+    graph.addEdge("D", "C")
+    assert.deepStrictEqual(graph.getDownstreamLeafNodes("A"), new Set(["C"]))
+    assert.deepStrictEqual(graph.getDownstreamLeafNodes("B"), new Set(["C"]))
+    assert.deepStrictEqual(graph.getDownstreamLeafNodes("C"), new Set(["C"]))
+    assert.deepStrictEqual(graph.getDownstreamLeafNodes("D"), new Set(["C"]))
+  })
+
+  test("getUpstreamsOfDownstreamLeafNodes", () => {
+    const graph = new DepGraph()
+    graph.addEdge("A", "B")
+    graph.addEdge("B", "C")
+    graph.addEdge("D", "B")
+    assert.deepStrictEqual(graph.getUpstreamsOfDownstreamLeafNodes("A"), new Set(["A", "B", "D"]))
+    assert.deepStrictEqual(graph.getUpstreamsOfDownstreamLeafNodes("B"), new Set(["A", "B", "D"]))
+    assert.deepStrictEqual(graph.getUpstreamsOfDownstreamLeafNodes("C"), new Set(["A", "B", "D"]))
+    assert.deepStrictEqual(graph.getUpstreamsOfDownstreamLeafNodes("D"), new Set(["A", "B", "D"]))
+  })
+
+  describe("mergeEdgesForNode", () => {
+    test("merges when node exists", () => {
+      // A -> B -> C
+      const graph = new DepGraph()
+      graph.addEdge("A", "B")
+      graph.addEdge("B", "C")
+
+      // B -> D
+      const other = new DepGraph()
+      other.addEdge("B", "D")
+
+      // B -> C removed, B -> D added
+      // A -> B -> D
+      graph.mergeEdgesForNode(other, "B")
+
+      const expected = {
+        options: { type: "directed", multi: false, allowSelfLoops: false },
+        attributes: {},
+        nodes: [{ key: "A" }, { key: "B" }, { key: "C" }, { key: "D" }],
+        edges: [
+          { key: "A -> B", source: "A", target: "B" },
+          { key: "B -> D", source: "B", target: "D" },
+        ],
+      }
+
+      assert.deepStrictEqual(graph.graph.toJSON(), expected)
+    })
+
+    test("adds node if it does not exist", () => {
+      // A -> B
+      const graph = new DepGraph()
+      graph.addEdge("A", "B")
+
+      // C -> D
+      const other = new DepGraph()
+      other.addEdge("C", "D")
+
+      // A -> B, C -> D
+      graph.mergeEdgesForNode(other, "C")
+
+      const expected = {
+        options: { type: "directed", multi: false, allowSelfLoops: false },
+        attributes: {},
+        nodes: [{ key: "A" }, { key: "B" }, { key: "C" }, { key: "D" }],
+        edges: [
+          { key: "A -> B", source: "A", target: "B" },
+          { key: "C -> D", source: "C", target: "D" },
+        ],
+      }
+
+      assert.deepStrictEqual(graph.graph.toJSON(), expected)
+    })
+  })
+})

--- a/quartz/depgraph.ts
+++ b/quartz/depgraph.ts
@@ -48,7 +48,9 @@ export default class DepGraph {
   }
 
   removeNode(node: string): void {
-    this.graph.dropNode(node)
+    if (this.graph.hasNode(node)) {
+      this.graph.dropNode(node)
+    }
   }
 
   getDownstreamLeafNodes(node: string): Set<string> {

--- a/quartz/depgraph.ts
+++ b/quartz/depgraph.ts
@@ -64,20 +64,22 @@ export default class DepGraph<T> {
     }
   }
 
+  // returns -1 if node does not exist
   outDegree(node: T): number {
-    return this._graph.get(node)!.outgoing.size
+    return this.hasNode(node) ? this._graph.get(node)!.outgoing.size : -1
   }
 
+  // returns -1 if node does not exist
   inDegree(node: T): number {
-    return this._graph.get(node)!.incoming.size
+    return this.hasNode(node) ? this._graph.get(node)!.incoming.size : -1
   }
 
   forEachOutNeighbor(node: T, callback: (neighbor: T) => void): void {
-    this._graph.get(node)!.outgoing.forEach(callback)
+    this._graph.get(node)?.outgoing.forEach(callback)
   }
 
   forEachInNeighbor(node: T, callback: (neighbor: T) => void): void {
-    this._graph.get(node)!.incoming.forEach(callback)
+    this._graph.get(node)?.incoming.forEach(callback)
   }
 
   forEachEdge(callback: (edge: [T, T]) => void): void {

--- a/quartz/depgraph.ts
+++ b/quartz/depgraph.ts
@@ -1,0 +1,121 @@
+import Graph from "graphology"
+
+export default class DepGraph {
+  graph: Graph
+
+  constructor() {
+    this.graph = new Graph({ allowSelfLoops: false, multi: false, type: "directed" })
+  }
+
+  toString(): string {
+    return JSON.stringify(
+      this.graph.toJSON()["edges"].map((obj) => obj["key"]),
+      null,
+      2,
+    )
+  }
+
+  // For the node provided:
+  // If node does not exist, add it
+  // If an edge was added in other, it is added in this graph
+  // If an edge was deleted in other, it is deleted in this graph
+  mergeEdgesForNode(other: DepGraph, node: string): void {
+    if (this.graph.hasNode(node)) {
+      this.graph.mergeNode(node)
+    }
+
+    // Add edge if it is present in other
+    other.graph.forEachEdge((_edge, _attr, source, target) => {
+      this.addEdge(source, target)
+    })
+
+    // For node provided, remove edge if it is absent in other
+    this.graph.forEachEdge((_edge, _attr, source, target) => {
+      if (source === node && !other.graph.hasEdge(source, target)) {
+        this.graph.dropEdge(source, target)
+      }
+    })
+  }
+
+  hasNode(node: string): boolean {
+    return this.graph.hasNode(node)
+  }
+
+  addEdge(from: string, to: string): void {
+    this.graph.mergeNode(from)
+    this.graph.mergeNode(to)
+    this.graph.mergeDirectedEdgeWithKey(`${from} -> ${to}`, from, to)
+  }
+
+  removeNode(node: string): void {
+    this.graph.dropNode(node)
+  }
+
+  getDownstreamLeafNodes(node: string): Set<string> {
+    let stack: string[] = [node]
+    let visited = new Set<string>()
+    let leafNodes = new Set<string>()
+
+    // DFS
+    while (stack.length > 0) {
+      let node = stack.pop()!
+
+      // If the node is already visited, skip it
+      if (visited.has(node)) {
+        continue
+      }
+      visited.add(node)
+
+      // Check if the node is a leaf node (i.e. destination path)
+      if (this.graph.outDegree(node) === 0) {
+        leafNodes.add(node)
+      }
+
+      // Add all unvisited neighbors to the stack
+      this.graph.forEachOutNeighbor(node, (neighbor) => {
+        if (!visited.has(neighbor)) {
+          stack.push(neighbor)
+        }
+      })
+    }
+
+    return leafNodes
+  }
+
+  // Eg. if the graph is A -> B -> C
+  //                     D ---^
+  // and the node is B, this function returns [A, B, D]
+  getUpstreamsOfDownstreamLeafNodes(node: string): Set<string> {
+    const leafNodes = this.getDownstreamLeafNodes(node)
+    let visited = new Set<string>()
+    let upstreamNodes = new Set<string>()
+
+    // Backwards DFS for each leaf node
+    leafNodes.forEach((leafNode) => {
+      let stack: string[] = [leafNode]
+
+      while (stack.length > 0) {
+        let node = stack.pop()!
+
+        if (visited.has(node)) {
+          continue
+        }
+        visited.add(node)
+        // Add node if it's not a leaf node (i.e. destination path)
+        // Assumes destination file cannot depend on another destination file
+        if (this.graph.outDegree(node) !== 0) {
+          upstreamNodes.add(node)
+        }
+
+        // Add all unvisited parents to the stack
+        this.graph.forEachInNeighbor(node, (parentNode) => {
+          if (!visited.has(parentNode)) {
+            stack.push(parentNode)
+          }
+        })
+      }
+    })
+
+    return upstreamNodes
+  }
+}

--- a/quartz/plugins/emitters/404.tsx
+++ b/quartz/plugins/emitters/404.tsx
@@ -29,7 +29,7 @@ export const NotFoundPage: QuartzEmitterPlugin = () => {
       return [Head, Body, pageBody, Footer]
     },
     async getDependencyGraph(_ctx, _content, _resources) {
-      return new DepGraph()
+      return new DepGraph<string>()
     },
     async emit(ctx, _content, resources): Promise<FilePath[]> {
       const cfg = ctx.cfg.configuration

--- a/quartz/plugins/emitters/404.tsx
+++ b/quartz/plugins/emitters/404.tsx
@@ -29,7 +29,7 @@ export const NotFoundPage: QuartzEmitterPlugin = () => {
       return [Head, Body, pageBody, Footer]
     },
     async getDependencyGraph(_ctx, _content, _resources) {
-      return new DepGraph<string>()
+      return new DepGraph<FilePath>()
     },
     async emit(ctx, _content, resources): Promise<FilePath[]> {
       const cfg = ctx.cfg.configuration

--- a/quartz/plugins/emitters/404.tsx
+++ b/quartz/plugins/emitters/404.tsx
@@ -9,6 +9,7 @@ import { NotFound } from "../../components"
 import { defaultProcessedContent } from "../vfile"
 import { write } from "./helpers"
 import { i18n } from "../../i18n"
+import DepGraph from "../../depgraph"
 
 export const NotFoundPage: QuartzEmitterPlugin = () => {
   const opts: FullPageLayout = {
@@ -26,6 +27,9 @@ export const NotFoundPage: QuartzEmitterPlugin = () => {
     name: "404Page",
     getQuartzComponents() {
       return [Head, Body, pageBody, Footer]
+    },
+    async getDependencyGraph(_ctx, _content, _resources) {
+      return new DepGraph()
     },
     async emit(ctx, _content, resources): Promise<FilePath[]> {
       const cfg = ctx.cfg.configuration

--- a/quartz/plugins/emitters/aliases.ts
+++ b/quartz/plugins/emitters/aliases.ts
@@ -2,11 +2,16 @@ import { FilePath, FullSlug, joinSegments, resolveRelative, simplifySlug } from 
 import { QuartzEmitterPlugin } from "../types"
 import path from "path"
 import { write } from "./helpers"
+import DepGraph from "../../depgraph"
 
 export const AliasRedirects: QuartzEmitterPlugin = () => ({
   name: "AliasRedirects",
   getQuartzComponents() {
     return []
+  },
+  async getDependencyGraph(_ctx, _content, _resources) {
+    // TODO implement
+    return new DepGraph()
   },
   async emit(ctx, content, _resources): Promise<FilePath[]> {
     const { argv } = ctx

--- a/quartz/plugins/emitters/aliases.ts
+++ b/quartz/plugins/emitters/aliases.ts
@@ -11,7 +11,7 @@ export const AliasRedirects: QuartzEmitterPlugin = () => ({
   },
   async getDependencyGraph(_ctx, _content, _resources) {
     // TODO implement
-    return new DepGraph<string>()
+    return new DepGraph<FilePath>()
   },
   async emit(ctx, content, _resources): Promise<FilePath[]> {
     const { argv } = ctx

--- a/quartz/plugins/emitters/aliases.ts
+++ b/quartz/plugins/emitters/aliases.ts
@@ -11,7 +11,7 @@ export const AliasRedirects: QuartzEmitterPlugin = () => ({
   },
   async getDependencyGraph(_ctx, _content, _resources) {
     // TODO implement
-    return new DepGraph()
+    return new DepGraph<string>()
   },
   async emit(ctx, content, _resources): Promise<FilePath[]> {
     const { argv } = ctx

--- a/quartz/plugins/emitters/assets.ts
+++ b/quartz/plugins/emitters/assets.ts
@@ -3,12 +3,31 @@ import { QuartzEmitterPlugin } from "../types"
 import path from "path"
 import fs from "fs"
 import { glob } from "../../util/glob"
+import DepGraph from "../../depgraph"
 
 export const Assets: QuartzEmitterPlugin = () => {
   return {
     name: "Assets",
     getQuartzComponents() {
       return []
+    },
+    async getDependencyGraph(ctx, _content, _resources) {
+      const { argv, cfg } = ctx
+      const graph = new DepGraph()
+
+      const fps = await glob("**", argv.directory, ["**/*.md", ...cfg.configuration.ignorePatterns])
+
+      for (const fp of fps) {
+        const ext = path.extname(fp)
+        const src = joinSegments(argv.directory, fp) as FilePath
+        const name = (slugifyFilePath(fp as FilePath, true) + ext) as FilePath
+
+        const dest = joinSegments(argv.output, name) as FilePath
+
+        graph.addEdge(src, dest)
+      }
+
+      return graph
     },
     async emit({ argv, cfg }, _content, _resources): Promise<FilePath[]> {
       // glob all non MD/MDX/HTML files in content folder and copy it over

--- a/quartz/plugins/emitters/assets.ts
+++ b/quartz/plugins/emitters/assets.ts
@@ -13,7 +13,7 @@ export const Assets: QuartzEmitterPlugin = () => {
     },
     async getDependencyGraph(ctx, _content, _resources) {
       const { argv, cfg } = ctx
-      const graph = new DepGraph()
+      const graph = new DepGraph<string>()
 
       const fps = await glob("**", argv.directory, ["**/*.md", ...cfg.configuration.ignorePatterns])
 

--- a/quartz/plugins/emitters/assets.ts
+++ b/quartz/plugins/emitters/assets.ts
@@ -13,7 +13,7 @@ export const Assets: QuartzEmitterPlugin = () => {
     },
     async getDependencyGraph(ctx, _content, _resources) {
       const { argv, cfg } = ctx
-      const graph = new DepGraph<string>()
+      const graph = new DepGraph<FilePath>()
 
       const fps = await glob("**", argv.directory, ["**/*.md", ...cfg.configuration.ignorePatterns])
 

--- a/quartz/plugins/emitters/cname.ts
+++ b/quartz/plugins/emitters/cname.ts
@@ -2,6 +2,7 @@ import { FilePath, joinSegments } from "../../util/path"
 import { QuartzEmitterPlugin } from "../types"
 import fs from "fs"
 import chalk from "chalk"
+import DepGraph from "../../depgraph"
 
 export function extractDomainFromBaseUrl(baseUrl: string) {
   const url = new URL(`https://${baseUrl}`)
@@ -12,6 +13,9 @@ export const CNAME: QuartzEmitterPlugin = () => ({
   name: "CNAME",
   getQuartzComponents() {
     return []
+  },
+  async getDependencyGraph(_ctx, _content, _resources) {
+    return new DepGraph()
   },
   async emit({ argv, cfg }, _content, _resources): Promise<FilePath[]> {
     if (!cfg.configuration.baseUrl) {

--- a/quartz/plugins/emitters/cname.ts
+++ b/quartz/plugins/emitters/cname.ts
@@ -15,7 +15,7 @@ export const CNAME: QuartzEmitterPlugin = () => ({
     return []
   },
   async getDependencyGraph(_ctx, _content, _resources) {
-    return new DepGraph()
+    return new DepGraph<string>()
   },
   async emit({ argv, cfg }, _content, _resources): Promise<FilePath[]> {
     if (!cfg.configuration.baseUrl) {

--- a/quartz/plugins/emitters/cname.ts
+++ b/quartz/plugins/emitters/cname.ts
@@ -15,7 +15,7 @@ export const CNAME: QuartzEmitterPlugin = () => ({
     return []
   },
   async getDependencyGraph(_ctx, _content, _resources) {
-    return new DepGraph<string>()
+    return new DepGraph<FilePath>()
   },
   async emit({ argv, cfg }, _content, _resources): Promise<FilePath[]> {
     if (!cfg.configuration.baseUrl) {

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -181,7 +181,7 @@ export const ComponentResources: QuartzEmitterPlugin<Options> = (opts?: Partial<
       // ContentPage emitter while creating the final html page. In order for
       // the reload logic to be included, and so for partial rebuilds to work,
       // we need to run this emitter for all markdown files.
-      const graph = new DepGraph<string>()
+      const graph = new DepGraph<FilePath>()
 
       for (const [_tree, file] of content) {
         const sourcePath = file.data.filePath!

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -181,7 +181,7 @@ export const ComponentResources: QuartzEmitterPlugin<Options> = (opts?: Partial<
       // ContentPage emitter while creating the final html page. In order for
       // the reload logic to be included, and so for partial rebuilds to work,
       // we need to run this emitter for all markdown files.
-      const graph = new DepGraph()
+      const graph = new DepGraph<string>()
 
       for (const [_tree, file] of content) {
         const sourcePath = file.data.filePath!

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -151,7 +151,7 @@ function addGlobalPageResources(
       contentType: "inline",
       script: `
           const socket = new WebSocket('${wsUrl}')
-          // reload(true) ensures resources like images and scripts are fetched again
+          // reload(true) ensures resources like images and scripts are fetched again in firefox
           socket.addEventListener('message', () => document.location.reload(true))
         `,
     })

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -1,4 +1,4 @@
-import { FilePath, FullSlug } from "../../util/path"
+import { FilePath, FullSlug, joinSegments } from "../../util/path"
 import { QuartzEmitterPlugin } from "../types"
 
 // @ts-ignore
@@ -14,6 +14,7 @@ import { googleFontHref, joinStyles } from "../../util/theme"
 import { Features, transform } from "lightningcss"
 import { transform as transpile } from "esbuild"
 import { write } from "./helpers"
+import DepGraph from "../../depgraph"
 
 type ComponentResources = {
   css: string[]
@@ -149,9 +150,10 @@ function addGlobalPageResources(
       loadTime: "afterDOMReady",
       contentType: "inline",
       script: `
-        const socket = new WebSocket('${wsUrl}')
-        socket.addEventListener('message', () => document.location.reload())
-      `,
+          const socket = new WebSocket('${wsUrl}')
+          // reload(true) ensures resources like images and scripts are fetched again
+          socket.addEventListener('message', () => document.location.reload(true))
+        `,
     })
   }
 }
@@ -170,6 +172,24 @@ export const ComponentResources: QuartzEmitterPlugin<Options> = (opts?: Partial<
     name: "ComponentResources",
     getQuartzComponents() {
       return []
+    },
+    async getDependencyGraph(ctx, content, _resources) {
+      // This emitter adds static resources to the `resources` parameter. One
+      // important resource this emitter adds is the code to start a websocket
+      // connection and listen to rebuild messages, which triggers a page reload.
+      // The resources parameter with the reload logic is later used by the
+      // ContentPage emitter while creating the final html page. In order for
+      // the reload logic to be included, and so for partial rebuilds to work,
+      // we need to run this emitter for all markdown files.
+      const graph = new DepGraph()
+
+      for (const [_tree, file] of content) {
+        const sourcePath = file.data.filePath!
+        const slug = file.data.slug!
+        graph.addEdge(sourcePath, joinSegments(ctx.argv.output, slug + ".html") as FilePath)
+      }
+
+      return graph
     },
     async emit(ctx, _content, resources): Promise<FilePath[]> {
       // component specific scripts and styles

--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -7,6 +7,7 @@ import { QuartzEmitterPlugin } from "../types"
 import { toHtml } from "hast-util-to-html"
 import { write } from "./helpers"
 import { i18n } from "../../i18n"
+import DepGraph from "../../depgraph"
 
 export type ContentIndex = Map<FullSlug, ContentDetails>
 export type ContentDetails = {
@@ -92,6 +93,26 @@ export const ContentIndex: QuartzEmitterPlugin<Partial<Options>> = (opts) => {
   opts = { ...defaultOptions, ...opts }
   return {
     name: "ContentIndex",
+    async getDependencyGraph(ctx, content, _resources) {
+      const graph = new DepGraph()
+
+      for (const [_tree, file] of content) {
+        const sourcePath = file.data.filePath!
+
+        graph.addEdge(
+          sourcePath,
+          joinSegments(ctx.argv.output, "static/contentIndex.json") as FilePath,
+        )
+        if (opts?.enableSiteMap) {
+          graph.addEdge(sourcePath, joinSegments(ctx.argv.output, "sitemap.xml") as FilePath)
+        }
+        if (opts?.enableRSS) {
+          graph.addEdge(sourcePath, joinSegments(ctx.argv.output, "index.xml") as FilePath)
+        }
+      }
+
+      return graph
+    },
     async emit(ctx, content, _resources) {
       const cfg = ctx.cfg.configuration
       const emitted: FilePath[] = []

--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -94,7 +94,7 @@ export const ContentIndex: QuartzEmitterPlugin<Partial<Options>> = (opts) => {
   return {
     name: "ContentIndex",
     async getDependencyGraph(ctx, content, _resources) {
-      const graph = new DepGraph()
+      const graph = new DepGraph<string>()
 
       for (const [_tree, file] of content) {
         const sourcePath = file.data.filePath!

--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -94,7 +94,7 @@ export const ContentIndex: QuartzEmitterPlugin<Partial<Options>> = (opts) => {
   return {
     name: "ContentIndex",
     async getDependencyGraph(ctx, content, _resources) {
-      const graph = new DepGraph<string>()
+      const graph = new DepGraph<FilePath>()
 
       for (const [_tree, file] of content) {
         const sourcePath = file.data.filePath!

--- a/quartz/plugins/emitters/contentPage.tsx
+++ b/quartz/plugins/emitters/contentPage.tsx
@@ -73,7 +73,7 @@ export const ContentPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOp
         fps.push(fp)
       }
 
-      if (!containsIndex) {
+      if (!containsIndex && !ctx.argv.fastRebuild) {
         console.log(
           chalk.yellow(
             `\nWarning: you seem to be missing an \`index.md\` home page file at the root of your \`${ctx.argv.directory}\` folder. This may cause errors when deploying.`,

--- a/quartz/plugins/emitters/contentPage.tsx
+++ b/quartz/plugins/emitters/contentPage.tsx
@@ -30,7 +30,7 @@ export const ContentPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOp
     },
     async getDependencyGraph(ctx, content, _resources) {
       // TODO handle transclusions
-      const graph = new DepGraph()
+      const graph = new DepGraph<string>()
 
       for (const [_tree, file] of content) {
         const sourcePath = file.data.filePath!

--- a/quartz/plugins/emitters/contentPage.tsx
+++ b/quartz/plugins/emitters/contentPage.tsx
@@ -30,7 +30,7 @@ export const ContentPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOp
     },
     async getDependencyGraph(ctx, content, _resources) {
       // TODO handle transclusions
-      const graph = new DepGraph<string>()
+      const graph = new DepGraph<FilePath>()
 
       for (const [_tree, file] of content) {
         const sourcePath = file.data.filePath!

--- a/quartz/plugins/emitters/folderPage.tsx
+++ b/quartz/plugins/emitters/folderPage.tsx
@@ -43,7 +43,7 @@ export const FolderPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOpt
       // nested/file.md --> nested/file.html
       //          \-------> nested/index.html
       // TODO implement
-      return new DepGraph<string>()
+      return new DepGraph<FilePath>()
     },
     async emit(ctx, content, resources): Promise<FilePath[]> {
       const fps: FilePath[] = []

--- a/quartz/plugins/emitters/folderPage.tsx
+++ b/quartz/plugins/emitters/folderPage.tsx
@@ -19,6 +19,7 @@ import { defaultListPageLayout, sharedPageComponents } from "../../../quartz.lay
 import { FolderContent } from "../../components"
 import { write } from "./helpers"
 import { i18n } from "../../i18n"
+import DepGraph from "../../depgraph"
 
 export const FolderPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOpts) => {
   const opts: FullPageLayout = {
@@ -36,6 +37,13 @@ export const FolderPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOpt
     name: "FolderPage",
     getQuartzComponents() {
       return [Head, Header, Body, ...header, ...beforeBody, pageBody, ...left, ...right, Footer]
+    },
+    async getDependencyGraph(ctx, content, _resources) {
+      // Example graph:
+      // nested/file.md --> nested/file.html
+      //          \-------> nested/index.html
+      // TODO implement
+      return new DepGraph()
     },
     async emit(ctx, content, resources): Promise<FilePath[]> {
       const fps: FilePath[] = []

--- a/quartz/plugins/emitters/folderPage.tsx
+++ b/quartz/plugins/emitters/folderPage.tsx
@@ -43,7 +43,7 @@ export const FolderPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOpt
       // nested/file.md --> nested/file.html
       //          \-------> nested/index.html
       // TODO implement
-      return new DepGraph()
+      return new DepGraph<string>()
     },
     async emit(ctx, content, resources): Promise<FilePath[]> {
       const fps: FilePath[] = []

--- a/quartz/plugins/emitters/static.ts
+++ b/quartz/plugins/emitters/static.ts
@@ -2,11 +2,23 @@ import { FilePath, QUARTZ, joinSegments } from "../../util/path"
 import { QuartzEmitterPlugin } from "../types"
 import fs from "fs"
 import { glob } from "../../util/glob"
+import DepGraph from "../../depgraph"
 
 export const Static: QuartzEmitterPlugin = () => ({
   name: "Static",
   getQuartzComponents() {
     return []
+  },
+  async getDependencyGraph({ argv, cfg }, _content, _resources) {
+    const graph = new DepGraph()
+
+    const staticPath = joinSegments(QUARTZ, "static")
+    const fps = await glob("**", staticPath, cfg.configuration.ignorePatterns)
+    for (const fp of fps) {
+      graph.addEdge(joinSegments("static", fp), joinSegments(argv.output, "static", fp) as FilePath)
+    }
+
+    return graph
   },
   async emit({ argv, cfg }, _content, _resources): Promise<FilePath[]> {
     const staticPath = joinSegments(QUARTZ, "static")

--- a/quartz/plugins/emitters/static.ts
+++ b/quartz/plugins/emitters/static.ts
@@ -10,12 +10,15 @@ export const Static: QuartzEmitterPlugin = () => ({
     return []
   },
   async getDependencyGraph({ argv, cfg }, _content, _resources) {
-    const graph = new DepGraph<string>()
+    const graph = new DepGraph<FilePath>()
 
     const staticPath = joinSegments(QUARTZ, "static")
     const fps = await glob("**", staticPath, cfg.configuration.ignorePatterns)
     for (const fp of fps) {
-      graph.addEdge(joinSegments("static", fp), joinSegments(argv.output, "static", fp) as FilePath)
+      graph.addEdge(
+        joinSegments("static", fp) as FilePath,
+        joinSegments(argv.output, "static", fp) as FilePath,
+      )
     }
 
     return graph

--- a/quartz/plugins/emitters/static.ts
+++ b/quartz/plugins/emitters/static.ts
@@ -10,7 +10,7 @@ export const Static: QuartzEmitterPlugin = () => ({
     return []
   },
   async getDependencyGraph({ argv, cfg }, _content, _resources) {
-    const graph = new DepGraph()
+    const graph = new DepGraph<string>()
 
     const staticPath = joinSegments(QUARTZ, "static")
     const fps = await glob("**", staticPath, cfg.configuration.ignorePatterns)

--- a/quartz/plugins/emitters/tagPage.tsx
+++ b/quartz/plugins/emitters/tagPage.tsx
@@ -37,7 +37,7 @@ export const TagPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOpts) 
     },
     async getDependencyGraph(ctx, _content, _resources) {
       // TODO implement
-      return new DepGraph()
+      return new DepGraph<string>()
     },
     async emit(ctx, content, resources): Promise<FilePath[]> {
       const fps: FilePath[] = []

--- a/quartz/plugins/emitters/tagPage.tsx
+++ b/quartz/plugins/emitters/tagPage.tsx
@@ -37,7 +37,7 @@ export const TagPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOpts) 
     },
     async getDependencyGraph(ctx, _content, _resources) {
       // TODO implement
-      return new DepGraph<string>()
+      return new DepGraph<FilePath>()
     },
     async emit(ctx, content, resources): Promise<FilePath[]> {
       const fps: FilePath[] = []

--- a/quartz/plugins/emitters/tagPage.tsx
+++ b/quartz/plugins/emitters/tagPage.tsx
@@ -16,6 +16,7 @@ import { defaultListPageLayout, sharedPageComponents } from "../../../quartz.lay
 import { TagContent } from "../../components"
 import { write } from "./helpers"
 import { i18n } from "../../i18n"
+import DepGraph from "../../depgraph"
 
 export const TagPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOpts) => {
   const opts: FullPageLayout = {
@@ -33,6 +34,10 @@ export const TagPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOpts) 
     name: "TagPage",
     getQuartzComponents() {
       return [Head, Header, Body, ...header, ...beforeBody, pageBody, ...left, ...right, Footer]
+    },
+    async getDependencyGraph(ctx, _content, _resources) {
+      // TODO implement
+      return new DepGraph()
     },
     async emit(ctx, content, resources): Promise<FilePath[]> {
       const fps: FilePath[] = []

--- a/quartz/plugins/types.ts
+++ b/quartz/plugins/types.ts
@@ -4,6 +4,7 @@ import { ProcessedContent } from "./vfile"
 import { QuartzComponent } from "../components/types"
 import { FilePath } from "../util/path"
 import { BuildCtx } from "../util/ctx"
+import DepGraph from "../depgraph"
 
 export interface PluginTypes {
   transformers: QuartzTransformerPluginInstance[]
@@ -38,4 +39,9 @@ export type QuartzEmitterPluginInstance = {
   name: string
   emit(ctx: BuildCtx, content: ProcessedContent[], resources: StaticResources): Promise<FilePath[]>
   getQuartzComponents(ctx: BuildCtx): QuartzComponent[]
+  getDependencyGraph(
+    ctx: BuildCtx,
+    content: ProcessedContent[],
+    resources: StaticResources,
+  ): Promise<DepGraph>
 }

--- a/quartz/plugins/types.ts
+++ b/quartz/plugins/types.ts
@@ -43,5 +43,5 @@ export type QuartzEmitterPluginInstance = {
     ctx: BuildCtx,
     content: ProcessedContent[],
     resources: StaticResources,
-  ): Promise<DepGraph>
+  ): Promise<DepGraph<string>>
 }

--- a/quartz/plugins/types.ts
+++ b/quartz/plugins/types.ts
@@ -43,5 +43,5 @@ export type QuartzEmitterPluginInstance = {
     ctx: BuildCtx,
     content: ProcessedContent[],
     resources: StaticResources,
-  ): Promise<DepGraph<string>>
+  ): Promise<DepGraph<FilePath>>
 }

--- a/quartz/plugins/types.ts
+++ b/quartz/plugins/types.ts
@@ -39,7 +39,7 @@ export type QuartzEmitterPluginInstance = {
   name: string
   emit(ctx: BuildCtx, content: ProcessedContent[], resources: StaticResources): Promise<FilePath[]>
   getQuartzComponents(ctx: BuildCtx): QuartzComponent[]
-  getDependencyGraph(
+  getDependencyGraph?(
     ctx: BuildCtx,
     content: ProcessedContent[],
     resources: StaticResources,

--- a/quartz/util/ctx.ts
+++ b/quartz/util/ctx.ts
@@ -6,6 +6,7 @@ export interface Argv {
   verbose: boolean
   output: string
   serve: boolean
+  fastRebuild: boolean
   port: number
   wsPort: number
   remoteDevHost?: string


### PR DESCRIPTION
### Summary
**Using partial rebuilds, this PR leads to a 98% reduction in build times, a ~50x improvement, saving 2.5 seconds on average** when using `npx quartz build --serve`.

This is large PR; it is best reviewed by commit.

## Motivation 
When running `npx quartz build --serve` in local development, changes often take multiple seconds to show up on the site. This is because the entire output directory is cleaned and rebuilt even when only one file is changed. If we delete and recreate only the necessary files, we can reduce the amount of time it takes for a change to be reflected.

## Changes
**Add `DepGraph`**, a class to track dependencies between files. It's based on the [graphology](https://graphology.github.io/) package.

**Implement a new method `getFileDependencies` on each emitter.** This returns a `DepGraph` that contains the file dependencies that the emitter cares about. For example:
```
contentPage:
a.md --> a.html
b.md --> b.html

contentIndex:
a.md --> contentIndex.json
b.md -----^
```

Some emitters don't have this method implemented properly and just return an empty dependency graph. Also, transclusions are currently unhandled. I will implement the logic for these cases in a future PR.

**Implement partial rebuild logic** in `partialRebuild`.
If a file is changed:
1. Reparse the file if it is a markdown file.
2. Get new dependencies from all emitters for this file. This is to handle new/removed transclusions.
3. For each emitter, if its dependency graph contains the changed file, get all the files needed to call the emitter (see this [doc](https://docs.google.com/document/d/1RcaAB7hE5fxAHfUxKF933Da8zdY4w_Fo3AlwVbiqJSw/edit#heading=h.vtwoh6b9l36a) for an explanation of how this is determined). For example, ContentIndex requires all .md files. Its graph might look like:
```
a.md --> contentIndex.json
b.md -----^
```
4. Call the emitter.

If a file is added:
1. Call `getDependencyGraph` for all emitters.
2. Update the exist dep graphs with the new graphs.
3. Same as step 3 in the file changed scenario.

If a file is deleted:
1. Mark the file for removal.
2. Call emitters with all files needed for the emitter, filtering out this file.
3. Remove the file from disk and all dependency graphs.

**Expose partial rebuilds on the cli** via `npx quartz build --serve --fastRebuild`

## Results
Summary: 98% reduction in build times, ~50x improvement, saving 2.5 seconds on average.

I ran ~20 iterations of a test to verify performance improvements on my local machine (see this PR for benchmarking setup). The test consisted of editing the last line of a markdown file, saving it, and measuring the rebuild function's execution time. I've plotted the results below.

![benchmark_plot](https://github.com/kabirgh/quartz/assets/15871468/0ba989e5-1226-4756-8cf1-5ae94116a8cd)

Mean time for full rebuilds: 2548 ms.
Mean time for partial rebuilds: 47 ms.

## Next
Implement `getDependencyGraph` for all emitters.