### PR TITLE
Benchmarking partial rebuilds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tsconfig.tsbuildinfo
 private/
 .replit
 replit.nix
+benchmark

--- a/content/1.md
+++ b/content/1.md
@@ -1,0 +1,6 @@
+---
+title: lsafas
+---
+
+Transclusion test
+![[2.md]]

--- a/content/2.md
+++ b/content/2.md
@@ -1,0 +1,6 @@
+---
+title: ghiur
+---
+
+as
+asf

--- a/content/incremental.md
+++ b/content/incremental.md
@@ -1,0 +1,115 @@
+---
+title: Partial rebuilds in Quartz
+---
+
+# 1. Build dependency graph
+
+When building files for the first time, call emitter.fileDependencies() for all emitters to get a mapping of source file paths to files written.
+
+```
+{a.md -> [a.html]}
+or
+{a.md -> [contentIndex.json], b.md -> [contentIndex.json]}
+```
+
+The build method merges the maps from all emitters to create a dependency graph.
+
+```
+a.md --contentPage--> a.html
+b.md --contentPage--> b.html
+
+a.md --contentIndex--> contentIndex.json
+b.md --contentIndex--> contentIndex.json
+```
+
+Alternatively: we maintain a separate graph for each emitter, which is simpler to implement.
+
+# 2. Rebuild on change
+
+## Change in source file
+
+When a source file changes:
+
+1. Look up the file in the dependency graph.
+2. Delete all the destinations for that file.
+3. Run the emitters that use that file.
+
+### Transclusion handling
+
+Let's take and example: a.md transcludes b.md via `![[b.md]]`
+
+So graph is:
+b.md -> a.md -> a.html
+b.md -> b.html
+
+If b.md changes, downstreams are [b.html, a.html]
+
+## New source file
+
+When a new source file is added:
+
+1. With this file, call emitter.fileDependencies() for all emitters to get a mapping of source file paths to files written.
+2. Update the dependency graph by merging fileDependencies for this file.
+3. Delete all the destinations for that file.
+4. Run the emitters that use that file.
+
+## File deleted
+
+When a source file is deleted:
+
+1. Look up the file in the dependency graph.
+2. Delete all the destinations for that file.
+3. Remove the file from the dependency graph.
+
+## File renames
+
+Treat as delete + create -- simple because chokidar emits unlink and add when a file is renamed.
+
+# TODOs
+
+- [ ] fileDependencies() for emitters; especially aliases, tags, folderpage
+- [ ] transclusions
+- [ ] sitemap, index.xml, contentIndex need all files supplied not just one
+
+# Scratchpad / notes
+
+## contentIndex handling
+
+graph:
+
+a.md --contentPage--> a.html
+b.md --contentPage--> b.html
+
+a.md --contentIndex--> contentIndex.json
+b.md --contentIndex--> contentIndex.json
+
+Builder:
+give all upstream of downstream files to emitter
+egs.
+
+- contentPage: a.md changed; downstream a.html, no other upstreams, so give a.md to contentPage emitter
+- contentIndex: a.md changed; downstream contentIndex.json, upstream a.md & b.md, so give a.md & b.md to contentIndex emitter
+
+## steps
+
+prepare code for incremental rebuilds
+
+1. [ ] move build into separate function outside of startServing.
+
+The approach to full and partial rebuild functions will be different enough that they should be different functions.This allows us to switch from
+
+```ts
+watcher.on("add", (fp) => rebuild(fp, "add"))
+```
+
+to
+
+```ts
+if (argv.partial) {
+  watcher.on("add", (fp) => partialRebuild(fp, "add", buildData))
+} else {
+  watcher.on("add", (fp) => fullRebuild(fp, "add", buildData))
+}
+```
+
+2. TODO...

--- a/content/index.md
+++ b/content/index.md
@@ -1,0 +1,11 @@
+---
+title: Home
+tags:
+  - sometag
+---
+
+# Hello
+
+This is a test sentence.
+
+This is a link to [google](https://google.com).

--- a/content/test.md
+++ b/content/test.md
@@ -1,0 +1,14 @@
+---
+title: Test
+tags:
+  - sometag
+  - nested/category
+---
+
+ascs
+
+NNG3gu1CFB
+VW57yrITW6
+crta467Ac5
+or1Wa88zWs
+FRn1Vrdn17

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@floating-ui/dom": "^1.5.3",
         "@napi-rs/simple-git": "0.1.9",
         "async-mutex": "^0.4.0",
+        "benchmark": "^2.1.4",
         "chalk": "^5.3.0",
         "chokidar": "^3.5.3",
         "cli-spinner": "^0.2.10",
@@ -21,6 +22,7 @@
         "flexsearch": "0.7.21",
         "github-slugger": "^2.0.0",
         "globby": "^14.0.0",
+        "graphology": "^0.25.4",
         "gray-matter": "^4.0.3",
         "hast-util-to-html": "^9.0.0",
         "hast-util-to-jsx-runtime": "^2.3.0",
@@ -69,6 +71,7 @@
         "quartz": "quartz/bootstrap-cli.mjs"
       },
       "devDependencies": {
+        "@types/benchmark": "^2.1.5",
         "@types/cli-spinner": "^0.2.3",
         "@types/d3": "^7.4.3",
         "@types/flexsearch": "^0.7.3",
@@ -738,6 +741,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@types/benchmark": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/benchmark/-/benchmark-2.1.5.tgz",
+      "integrity": "sha512-cKio2eFB3v7qmKcvIHLUMw/dIx/8bhWPuzpzRT4unCPRTD8VdA9Zb0afxpcxOqR4PixRS7yT42FqGS8BYL8g1w==",
+      "dev": true
+    },
     "node_modules/@types/cli-spinner": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@types/cli-spinner/-/cli-spinner-0.2.3.tgz",
@@ -1236,6 +1245,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "dependencies": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -2106,6 +2124,14 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -2313,6 +2339,24 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/graphology": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/graphology/-/graphology-0.25.4.tgz",
+      "integrity": "sha512-33g0Ol9nkWdD6ulw687viS8YJQBxqG5LWII6FI6nul0pq6iM2t5EKquOTFDbyTblRB3O9I+7KX4xI8u5ffekAQ==",
+      "dependencies": {
+        "events": "^3.3.0",
+        "obliterator": "^2.0.2"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.24.0"
+      }
+    },
+    "node_modules/graphology-types": {
+      "version": "0.24.7",
+      "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.24.7.tgz",
+      "integrity": "sha512-tdcqOOpwArNjEr0gNQKCXwaNCWnQJrog14nJNQPeemcLnXQUUGrsCWpWkVKt46zLjcS6/KGoayeJfHHyPDlvwA==",
+      "peer": true
     },
     "node_modules/gray-matter": {
       "version": "4.0.3",
@@ -3223,6 +3267,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -4336,6 +4385,11 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
       "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ=="
     },
+    "node_modules/obliterator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
+      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
+    },
     "node_modules/parse-entities": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.1.tgz",
@@ -4449,6 +4503,11 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "node_modules/preact": {
       "version": "10.19.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "check": "tsc --noEmit && npx prettier . --check",
     "format": "npx prettier . --write",
     "test": "tsx ./quartz/util/path.test.ts && tsx ./quartz/depgraph.test.ts",
-    "profile": "0x -D prof ./quartz/bootstrap-cli.mjs build --concurrency=1"
+    "profile": "0x -D prof ./quartz/bootstrap-cli.mjs build --concurrency=1",
+    "bench": "tsx ./quartz/benchmark.ts"
   },
   "engines": {
     "npm": ">=9.3.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "docs": "npx quartz build --serve -d docs",
     "check": "tsc --noEmit && npx prettier . --check",
     "format": "npx prettier . --write",
-    "test": "tsx ./quartz/util/path.test.ts",
+    "test": "tsx ./quartz/util/path.test.ts && tsx ./quartz/depgraph.test.ts",
     "profile": "0x -D prof ./quartz/bootstrap-cli.mjs build --concurrency=1"
   },
   "engines": {
@@ -38,6 +38,7 @@
     "@floating-ui/dom": "^1.5.3",
     "@napi-rs/simple-git": "0.1.9",
     "async-mutex": "^0.4.0",
+    "benchmark": "^2.1.4",
     "chalk": "^5.3.0",
     "chokidar": "^3.5.3",
     "cli-spinner": "^0.2.10",
@@ -46,6 +47,7 @@
     "flexsearch": "0.7.21",
     "github-slugger": "^2.0.0",
     "globby": "^14.0.0",
+    "graphology": "^0.25.4",
     "gray-matter": "^4.0.3",
     "hast-util-to-html": "^9.0.0",
     "hast-util-to-jsx-runtime": "^2.3.0",
@@ -91,6 +93,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
+    "@types/benchmark": "^2.1.5",
     "@types/cli-spinner": "^0.2.3",
     "@types/d3": "^7.4.3",
     "@types/flexsearch": "^0.7.3",

--- a/quartz/benchmark.ts
+++ b/quartz/benchmark.ts
@@ -1,0 +1,68 @@
+import fs from "fs"
+import subProcess from "child_process"
+
+// Set up test.md file
+const filename = "C:\\Users\\Kabir\\Documents\\Projects\\quartz\\content\\test.md"
+let lastline = generateRandomAsciiString(10)
+
+fs.readFile(filename, "utf8", function (_err, data) {
+  let newdata = data + `\n${lastline}`
+  fs.writeFileSync(filename, newdata)
+})
+
+// setup quartz in serve mode
+// const child = subProcess.spawn("npx", "quartz build --serve --output benchmark".split(" "), {
+const child = subProcess.spawn(
+  "npx",
+  "quartz build --serve --fastRebuild --output benchmark".split(" "),
+  {
+    cwd: "C:\\Users\\Kabir\\Documents\\Projects\\quartz",
+    shell: true,
+  },
+)
+
+// Listen for standard output data
+child.stdout.on("data", (data) => {
+  console.log(`stdout: ${data}`)
+})
+
+// Listen for standard error data
+child.stderr.on("data", (data) => {
+  console.error(`stderr: ${data}`)
+})
+
+// Handle the close event of the child process
+child.on("close", (code) => {
+  console.log(`child process exited with code ${code}`)
+})
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+// wait for build to finish
+await delay(7000)
+
+function generateRandomAsciiString(length: number) {
+  let result = ""
+  const characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+  const charactersLength = characters.length
+
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength))
+  }
+
+  return result
+}
+
+// edit test.md (change last line to random text) and save
+for (let i = 0; i < 20; i++) {
+  fs.readFile(filename, "utf8", function (_err, data) {
+    let nextline = generateRandomAsciiString(10)
+    let newdata = data.replace(lastline, nextline)
+    lastline = nextline
+    fs.writeFileSync(filename, newdata)
+  })
+
+  await delay(6000)
+}
+
+child.kill()
+console.log("---------- DONE ----------")

--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -24,8 +24,6 @@ type BuildData = {
   mut: Mutex
   initialSlugs: FullSlug[]
   contentMap: Map<FilePath, ProcessedContent>
-  toRebuild: Set<FilePath>
-  toRemove: Set<FilePath>
   trackedAssets: Set<FilePath>
   lastBuildMs: number
 }
@@ -97,8 +95,6 @@ async function startServing(
     contentMap,
     ignored: await isGitIgnored(),
     initialSlugs: ctx.allSlugs,
-    toRebuild: new Set<FilePath>(),
-    toRemove: new Set<FilePath>(),
     trackedAssets: new Set<FilePath>(),
     lastBuildMs: 0,
   }
@@ -125,19 +121,12 @@ async function rebuild(
   clientRefresh: () => void,
   buildData: BuildData, // note: this function mutates buildData
 ) {
-  const {
-    ctx,
-    ignored,
-    mut,
-    initialSlugs,
-    contentMap,
-    toRebuild,
-    toRemove,
-    trackedAssets,
-    lastBuildMs,
-  } = buildData
+  const { ctx, ignored, mut, initialSlugs, contentMap, trackedAssets, lastBuildMs } = buildData
 
   const { argv } = ctx
+
+  const toRebuild = new Set<FilePath>()
+  const toRemove = new Set<FilePath>()
 
   // don't do anything for gitignored files
   if (ignored(fp)) {
@@ -210,8 +199,6 @@ async function rebuild(
 
   release()
   clientRefresh()
-  toRebuild.clear()
-  toRemove.clear()
 }
 
 export default async (argv: Argv, mut: Mutex, clientRefresh: () => void) => {

--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -3,13 +3,13 @@ sourceMapSupport.install(options)
 import path from "path"
 import { PerfTimer } from "./util/perf"
 import { rimraf } from "rimraf"
-import { isGitIgnored } from "globby"
+import { GlobbyFilterFunction, isGitIgnored } from "globby"
 import chalk from "chalk"
 import { parseMarkdown } from "./processors/parse"
 import { filterContent } from "./processors/filter"
 import { emitContent } from "./processors/emit"
 import cfg from "../quartz.config"
-import { FilePath, joinSegments, slugifyFilePath } from "./util/path"
+import { FilePath, FullSlug, joinSegments, slugifyFilePath } from "./util/path"
 import chokidar from "chokidar"
 import { ProcessedContent } from "./plugins/vfile"
 import { Argv, BuildCtx } from "./util/ctx"
@@ -17,6 +17,18 @@ import { glob, toPosixPath } from "./util/glob"
 import { trace } from "./util/trace"
 import { options } from "./util/sourcemap"
 import { Mutex } from "async-mutex"
+
+type BuildData = {
+  ctx: BuildCtx
+  ignored: GlobbyFilterFunction
+  mut: Mutex
+  initialSlugs: FullSlug[]
+  contentMap: Map<FilePath, ProcessedContent>
+  toRebuild: Set<FilePath>
+  toRemove: Set<FilePath>
+  trackedAssets: Set<FilePath>
+  lastBuildMs: number
+}
 
 async function buildQuartz(argv: Argv, mut: Mutex, clientRefresh: () => void) {
   const ctx: BuildCtx = {
@@ -73,92 +85,22 @@ async function startServing(
 ) {
   const { argv } = ctx
 
-  const ignored = await isGitIgnored()
   const contentMap = new Map<FilePath, ProcessedContent>()
   for (const content of initialContent) {
     const [_tree, vfile] = content
     contentMap.set(vfile.data.filePath!, content)
   }
 
-  const initialSlugs = ctx.allSlugs
-  let lastBuildMs = 0
-  const toRebuild: Set<FilePath> = new Set()
-  const toRemove: Set<FilePath> = new Set()
-  const trackedAssets: Set<FilePath> = new Set()
-  async function rebuild(fp: string, action: "add" | "change" | "delete") {
-    // don't do anything for gitignored files
-    if (ignored(fp)) {
-      return
-    }
-
-    // dont bother rebuilding for non-content files, just track and refresh
-    fp = toPosixPath(fp)
-    const filePath = joinSegments(argv.directory, fp) as FilePath
-    if (path.extname(fp) !== ".md") {
-      if (action === "add" || action === "change") {
-        trackedAssets.add(filePath)
-      } else if (action === "delete") {
-        trackedAssets.delete(filePath)
-      }
-      clientRefresh()
-      return
-    }
-
-    if (action === "add" || action === "change") {
-      toRebuild.add(filePath)
-    } else if (action === "delete") {
-      toRemove.add(filePath)
-    }
-
-    // debounce rebuilds every 250ms
-
-    const buildStart = new Date().getTime()
-    lastBuildMs = buildStart
-    const release = await mut.acquire()
-    if (lastBuildMs > buildStart) {
-      release()
-      return
-    }
-
-    const perf = new PerfTimer()
-    console.log(chalk.yellow("Detected change, rebuilding..."))
-    try {
-      const filesToRebuild = [...toRebuild].filter((fp) => !toRemove.has(fp))
-
-      const trackedSlugs = [...new Set([...contentMap.keys(), ...toRebuild, ...trackedAssets])]
-        .filter((fp) => !toRemove.has(fp))
-        .map((fp) => slugifyFilePath(path.posix.relative(argv.directory, fp) as FilePath))
-
-      ctx.allSlugs = [...new Set([...initialSlugs, ...trackedSlugs])]
-      const parsedContent = await parseMarkdown(ctx, filesToRebuild)
-      for (const content of parsedContent) {
-        const [_tree, vfile] = content
-        contentMap.set(vfile.data.filePath!, content)
-      }
-
-      for (const fp of toRemove) {
-        contentMap.delete(fp)
-      }
-
-      const parsedFiles = [...contentMap.values()]
-      const filteredContent = filterContent(ctx, parsedFiles)
-
-      // TODO: we can probably traverse the link graph to figure out what's safe to delete here
-      // instead of just deleting everything
-      await rimraf(argv.output)
-      await emitContent(ctx, filteredContent)
-      console.log(chalk.green(`Done rebuilding in ${perf.timeSince()}`))
-    } catch (err) {
-      console.log(chalk.yellow(`Rebuild failed. Waiting on a change to fix the error...`))
-      if (argv.verbose) {
-        console.log(chalk.red(err))
-      }
-    }
-
-    release()
-    clientRefresh()
-    toRebuild.clear()
-    toRemove.clear()
+  const buildData: BuildData = {
+    ctx,
+    mut,
+    contentMap,
+    ignored: await isGitIgnored(),
+    initialSlugs: ctx.allSlugs,
+    toRebuild: new Set<FilePath>(),
+    toRemove: new Set<FilePath>(),
+    trackedAssets: new Set<FilePath>(),
+    lastBuildMs: 0,
   }
 
   const watcher = chokidar.watch(".", {
@@ -168,13 +110,108 @@ async function startServing(
   })
 
   watcher
-    .on("add", (fp) => rebuild(fp, "add"))
-    .on("change", (fp) => rebuild(fp, "change"))
-    .on("unlink", (fp) => rebuild(fp, "delete"))
+    .on("add", (fp) => rebuild(fp, "add", clientRefresh, buildData))
+    .on("change", (fp) => rebuild(fp, "change", clientRefresh, buildData))
+    .on("unlink", (fp) => rebuild(fp, "delete", clientRefresh, buildData))
 
   return async () => {
     await watcher.close()
   }
+}
+
+async function rebuild(
+  fp: string,
+  action: "add" | "change" | "delete",
+  clientRefresh: () => void,
+  buildData: BuildData, // note: this function mutates buildData
+) {
+  const {
+    ctx,
+    ignored,
+    mut,
+    initialSlugs,
+    contentMap,
+    toRebuild,
+    toRemove,
+    trackedAssets,
+    lastBuildMs,
+  } = buildData
+
+  const { argv } = ctx
+
+  // don't do anything for gitignored files
+  if (ignored(fp)) {
+    return
+  }
+
+  // dont bother rebuilding for non-content files, just track and refresh
+  fp = toPosixPath(fp)
+  const filePath = joinSegments(argv.directory, fp) as FilePath
+  if (path.extname(fp) !== ".md") {
+    if (action === "add" || action === "change") {
+      trackedAssets.add(filePath)
+    } else if (action === "delete") {
+      trackedAssets.delete(filePath)
+    }
+    clientRefresh()
+    return
+  }
+
+  if (action === "add" || action === "change") {
+    toRebuild.add(filePath)
+  } else if (action === "delete") {
+    toRemove.add(filePath)
+  }
+
+  // debounce rebuilds every 250ms
+
+  const buildStart = new Date().getTime()
+  buildData.lastBuildMs = buildStart
+  const release = await mut.acquire()
+  if (lastBuildMs > buildStart) {
+    release()
+    return
+  }
+
+  const perf = new PerfTimer()
+  console.log(chalk.yellow("Detected change, rebuilding..."))
+  try {
+    const filesToRebuild = [...toRebuild].filter((fp) => !toRemove.has(fp))
+
+    const trackedSlugs = [...new Set([...contentMap.keys(), ...toRebuild, ...trackedAssets])]
+      .filter((fp) => !toRemove.has(fp))
+      .map((fp) => slugifyFilePath(path.posix.relative(argv.directory, fp) as FilePath))
+
+    ctx.allSlugs = [...new Set([...initialSlugs, ...trackedSlugs])]
+    const parsedContent = await parseMarkdown(ctx, filesToRebuild)
+    for (const content of parsedContent) {
+      const [_tree, vfile] = content
+      contentMap.set(vfile.data.filePath!, content)
+    }
+
+    for (const fp of toRemove) {
+      contentMap.delete(fp)
+    }
+
+    const parsedFiles = [...contentMap.values()]
+    const filteredContent = filterContent(ctx, parsedFiles)
+
+    // TODO: we can probably traverse the link graph to figure out what's safe to delete here
+    // instead of just deleting everything
+    await rimraf(argv.output)
+    await emitContent(ctx, filteredContent)
+    console.log(chalk.green(`Done rebuilding in ${perf.timeSince()}`))
+  } catch (err) {
+    console.log(chalk.yellow(`Rebuild failed. Waiting on a change to fix the error...`))
+    if (argv.verbose) {
+      console.log(chalk.red(err))
+    }
+  }
+
+  release()
+  clientRefresh()
+  toRebuild.clear()
+  toRemove.clear()
 }
 
 export default async (argv: Argv, mut: Mutex, clientRefresh: () => void) => {

--- a/quartz/cli/args.js
+++ b/quartz/cli/args.js
@@ -71,6 +71,11 @@ export const BuildArgv = {
     default: false,
     describe: "run a local server to live-preview your Quartz",
   },
+  fastRebuild: {
+    boolean: true,
+    default: false,
+    describe: "[experimental] rebuild only the changed files",
+  },
   baseDir: {
     string: true,
     default: "",

--- a/quartz/depgraph.test.ts
+++ b/quartz/depgraph.test.ts
@@ -1,0 +1,78 @@
+import test, { describe } from "node:test"
+import DepGraph from "./depgraph"
+import assert from "node:assert"
+
+describe("DepGraph", () => {
+  test("getDownstreamLeafNodes", () => {
+    const graph = new DepGraph()
+    graph.addEdge("A", "B")
+    graph.addEdge("B", "C")
+    graph.addEdge("D", "C")
+    assert.deepStrictEqual(graph.getDownstreamLeafNodes("A"), new Set(["C"]))
+    assert.deepStrictEqual(graph.getDownstreamLeafNodes("B"), new Set(["C"]))
+    assert.deepStrictEqual(graph.getDownstreamLeafNodes("C"), new Set(["C"]))
+    assert.deepStrictEqual(graph.getDownstreamLeafNodes("D"), new Set(["C"]))
+  })
+
+  test("getUpstreamsOfDownstreamLeafNodes", () => {
+    const graph = new DepGraph()
+    graph.addEdge("A", "B")
+    graph.addEdge("B", "C")
+    graph.addEdge("D", "B")
+    assert.deepStrictEqual(graph.getUpstreamsOfDownstreamLeafNodes("A"), new Set(["A", "B", "D"]))
+    assert.deepStrictEqual(graph.getUpstreamsOfDownstreamLeafNodes("B"), new Set(["A", "B", "D"]))
+    assert.deepStrictEqual(graph.getUpstreamsOfDownstreamLeafNodes("C"), new Set(["A", "B", "D"]))
+    assert.deepStrictEqual(graph.getUpstreamsOfDownstreamLeafNodes("D"), new Set(["A", "B", "D"]))
+  })
+
+  describe("mergeEdgesForNode", () => {
+    test("merges when node exists", () => {
+      // A -> B -> C
+      const graph = new DepGraph()
+      graph.addEdge("A", "B")
+      graph.addEdge("B", "C")
+
+      // B -> D
+      const other = new DepGraph()
+      other.addEdge("B", "D")
+
+      // B -> C removed, B -> D added
+      // A -> B -> D
+      graph.mergeEdgesForNode(other, "B")
+
+      const expected = {
+        options: { type: "directed", multi: false, allowSelfLoops: false },
+        attributes: {},
+        nodes: [{ key: "A" }, { key: "B" }, { key: "C" }, { key: "D" }],
+        edges: [
+          { key: "A -> B", source: "A", target: "B" },
+          { key: "B -> D", source: "B", target: "D" },
+        ],
+      }
+
+      assert.deepStrictEqual(graph.graph.toJSON(), expected)
+    })
+
+    test("does not merge if node does not exist", () => {
+      // A -> B
+      const graph = new DepGraph()
+      graph.addEdge("A", "B")
+
+      // C -> D
+      const other = new DepGraph()
+      other.addEdge("C", "D")
+
+      // A -> B
+      graph.mergeEdgesForNode(other, "C")
+
+      const expected = {
+        options: { type: "directed", multi: false, allowSelfLoops: false },
+        attributes: {},
+        nodes: [{ key: "A" }, { key: "B" }],
+        edges: [{ key: "A -> B", source: "A", target: "B" }],
+      }
+
+      assert.deepStrictEqual(graph.graph.toJSON(), expected)
+    })
+  })
+})

--- a/quartz/depgraph.ts
+++ b/quartz/depgraph.ts
@@ -1,0 +1,121 @@
+import Graph from "graphology"
+
+export default class DepGraph {
+  graph: Graph
+
+  constructor() {
+    this.graph = new Graph({ allowSelfLoops: false, multi: false, type: "directed" })
+  }
+
+  toString(): string {
+    return JSON.stringify(
+      this.graph.toJSON()["edges"].map((obj) => obj["key"]),
+      null,
+      2,
+    )
+  }
+
+  // For the node provided:
+  // If node does not exist, do nothing
+  // If an edge was added in other, it is added in this graph
+  // If an edge was deleted in other, it is deleted in this graph
+  mergeEdgesForNode(other: DepGraph, node: string): void {
+    if (!this.graph.hasNode(node)) {
+      return
+    }
+
+    // Add edge if it is present in other
+    other.graph.forEachEdge((_edge, _attr, source, target) => {
+      this.addEdge(source, target)
+    })
+
+    // For node provided, remove edge if it is absent in other
+    this.graph.forEachEdge((_edge, _attr, source, target) => {
+      if (source === node && !other.graph.hasEdge(source, target)) {
+        this.graph.dropEdge(source, target)
+      }
+    })
+  }
+
+  hasNode(node: string): boolean {
+    return this.graph.hasNode(node)
+  }
+
+  addEdge(from: string, to: string): void {
+    this.graph.mergeNode(from)
+    this.graph.mergeNode(to)
+    this.graph.mergeDirectedEdgeWithKey(`${from} -> ${to}`, from, to)
+  }
+
+  removeNode(node: string): void {
+    this.graph.dropNode(node)
+  }
+
+  getDownstreamLeafNodes(node: string): Set<string> {
+    let stack: string[] = [node]
+    let visited = new Set<string>()
+    let leafNodes = new Set<string>()
+
+    // DFS
+    while (stack.length > 0) {
+      let node = stack.pop()!
+
+      // If the node is already visited, skip it
+      if (visited.has(node)) {
+        continue
+      }
+      visited.add(node)
+
+      // Check if the node is a leaf node (i.e. destination path)
+      if (this.graph.outDegree(node) === 0) {
+        leafNodes.add(node)
+      }
+
+      // Add all unvisited neighbors to the stack
+      this.graph.forEachOutNeighbor(node, (neighbor) => {
+        if (!visited.has(neighbor)) {
+          stack.push(neighbor)
+        }
+      })
+    }
+
+    return leafNodes
+  }
+
+  // Eg. if the graph is A -> B -> C
+  //                     D ---^
+  // and the node is B, this function returns [A, B, D]
+  getUpstreamsOfDownstreamLeafNodes(node: string): Set<string> {
+    const leafNodes = this.getDownstreamLeafNodes(node)
+    let visited = new Set<string>()
+    let upstreamNodes = new Set<string>()
+
+    // Backwards DFS for each leaf node
+    leafNodes.forEach((leafNode) => {
+      let stack: string[] = [leafNode]
+
+      while (stack.length > 0) {
+        let node = stack.pop()!
+
+        if (visited.has(node)) {
+          continue
+        }
+        visited.add(node)
+        // Add node if it's not a leaf node (i.e. destination path)
+        // Assumes destination file cannot depend on another destination file
+        if (this.graph.outDegree(node) !== 0) {
+          upstreamNodes.add(node)
+        }
+
+        // Add all unvisited parents to the stack
+        this.graph.forEachInNeighbor(node, (parentNode) => {
+          if (!visited.has(parentNode)) {
+            stack.push(parentNode)
+          }
+        })
+      }
+    })
+
+    return upstreamNodes
+  }
+}

--- a/quartz/depgraph.ts
+++ b/quartz/depgraph.ts
@@ -48,7 +48,9 @@ export default class DepGraph {
   }
 
   removeNode(node: string): void {
-    this.graph.dropNode(node)
+    if (this.graph.hasNode(node)) {
+      this.graph.dropNode(node)
+    }
   }
 
   getDownstreamLeafNodes(node: string): Set<string> {

--- a/quartz/plugins/emitters/404.tsx
+++ b/quartz/plugins/emitters/404.tsx
@@ -8,6 +8,7 @@ import { sharedPageComponents } from "../../../quartz.layout"
 import { NotFound } from "../../components"
 import { defaultProcessedContent } from "../vfile"
 import { write } from "./helpers"
+import DepGraph from "../../depgraph"
 
 export const NotFoundPage: QuartzEmitterPlugin = () => {
   const opts: FullPageLayout = {
@@ -25,6 +26,9 @@ export const NotFoundPage: QuartzEmitterPlugin = () => {
     name: "404Page",
     getQuartzComponents() {
       return [Head, Body, pageBody, Footer]
+    },
+    async getDependencyGraph(_ctx, _content, _resources) {
+      return new DepGraph()
     },
     async emit(ctx, _content, resources): Promise<FilePath[]> {
       const cfg = ctx.cfg.configuration

--- a/quartz/plugins/emitters/aliases.ts
+++ b/quartz/plugins/emitters/aliases.ts
@@ -2,11 +2,16 @@ import { FilePath, FullSlug, joinSegments, resolveRelative, simplifySlug } from 
 import { QuartzEmitterPlugin } from "../types"
 import path from "path"
 import { write } from "./helpers"
+import DepGraph from "../../depgraph"
 
 export const AliasRedirects: QuartzEmitterPlugin = () => ({
   name: "AliasRedirects",
   getQuartzComponents() {
     return []
+  },
+  async getDependencyGraph(_ctx, _content, _resources) {
+    // TODO implement
+    return new DepGraph()
   },
   async emit(ctx, content, _resources): Promise<FilePath[]> {
     const { argv } = ctx

--- a/quartz/plugins/emitters/assets.ts
+++ b/quartz/plugins/emitters/assets.ts
@@ -3,12 +3,31 @@ import { QuartzEmitterPlugin } from "../types"
 import path from "path"
 import fs from "fs"
 import { glob } from "../../util/glob"
+import DepGraph from "../../depgraph"
 
 export const Assets: QuartzEmitterPlugin = () => {
   return {
     name: "Assets",
     getQuartzComponents() {
       return []
+    },
+    async getDependencyGraph(ctx, _content, _resources) {
+      const { argv, cfg } = ctx
+      const graph = new DepGraph()
+
+      const fps = await glob("**", argv.directory, ["**/*.md", ...cfg.configuration.ignorePatterns])
+
+      for (const fp of fps) {
+        const ext = path.extname(fp)
+        const src = joinSegments(argv.directory, fp) as FilePath
+        const name = (slugifyFilePath(fp as FilePath, true) + ext) as FilePath
+
+        const dest = joinSegments(argv.output, name) as FilePath
+
+        graph.addEdge(src, dest)
+      }
+
+      return graph
     },
     async emit({ argv, cfg }, _content, _resources): Promise<FilePath[]> {
       // glob all non MD/MDX/HTML files in content folder and copy it over

--- a/quartz/plugins/emitters/cname.ts
+++ b/quartz/plugins/emitters/cname.ts
@@ -2,6 +2,7 @@ import { FilePath, joinSegments } from "../../util/path"
 import { QuartzEmitterPlugin } from "../types"
 import fs from "fs"
 import chalk from "chalk"
+import DepGraph from "../../depgraph"
 
 export function extractDomainFromBaseUrl(baseUrl: string) {
   const url = new URL(`https://${baseUrl}`)
@@ -12,6 +13,9 @@ export const CNAME: QuartzEmitterPlugin = () => ({
   name: "CNAME",
   getQuartzComponents() {
     return []
+  },
+  async getDependencyGraph(_ctx, _content, _resources) {
+    return new DepGraph()
   },
   async emit({ argv, cfg }, _content, _resources): Promise<FilePath[]> {
     if (!cfg.configuration.baseUrl) {

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -14,6 +14,7 @@ import { googleFontHref, joinStyles } from "../../util/theme"
 import { Features, transform } from "lightningcss"
 import { transform as transpile } from "esbuild"
 import { write } from "./helpers"
+import DepGraph from "../../depgraph"
 
 type ComponentResources = {
   css: string[]
@@ -168,6 +169,9 @@ export const ComponentResources: QuartzEmitterPlugin<Options> = (opts?: Partial<
     name: "ComponentResources",
     getQuartzComponents() {
       return []
+    },
+    async getDependencyGraph(_ctx, _content, _resources) {
+      return new DepGraph()
     },
     async emit(ctx, _content, resources): Promise<FilePath[]> {
       // component specific scripts and styles

--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -7,6 +7,7 @@ import { QuartzEmitterPlugin } from "../types"
 import { toHtml } from "hast-util-to-html"
 import path from "path"
 import { write } from "./helpers"
+import DepGraph from "../../depgraph"
 
 export type ContentIndex = Map<FullSlug, ContentDetails>
 export type ContentDetails = {
@@ -92,6 +93,26 @@ export const ContentIndex: QuartzEmitterPlugin<Partial<Options>> = (opts) => {
   opts = { ...defaultOptions, ...opts }
   return {
     name: "ContentIndex",
+    async getDependencyGraph(ctx, content, _resources) {
+      const graph = new DepGraph()
+
+      for (const [_tree, file] of content) {
+        const sourcePath = file.data.filePath!
+
+        graph.addEdge(
+          sourcePath,
+          joinSegments(ctx.argv.output, "static/contentIndex.json") as FilePath,
+        )
+        if (opts?.enableSiteMap) {
+          graph.addEdge(sourcePath, joinSegments(ctx.argv.output, "sitemap.xml") as FilePath)
+        }
+        if (opts?.enableRSS) {
+          graph.addEdge(sourcePath, joinSegments(ctx.argv.output, "index.xml") as FilePath)
+        }
+      }
+
+      return graph
+    },
     async emit(ctx, content, _resources) {
       const cfg = ctx.cfg.configuration
       const emitted: FilePath[] = []

--- a/quartz/plugins/emitters/contentPage.tsx
+++ b/quartz/plugins/emitters/contentPage.tsx
@@ -73,7 +73,7 @@ export const ContentPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOp
         fps.push(fp)
       }
 
-      if (!containsIndex) {
+      if (!containsIndex && !ctx.argv.fastRebuild) {
         console.log(
           chalk.yellow(
             `\nWarning: you seem to be missing an \`index.md\` home page file at the root of your \`${ctx.argv.directory}\` folder. This may cause errors when deploying.`,

--- a/quartz/plugins/emitters/folderPage.tsx
+++ b/quartz/plugins/emitters/folderPage.tsx
@@ -18,6 +18,7 @@ import {
 import { defaultListPageLayout, sharedPageComponents } from "../../../quartz.layout"
 import { FolderContent } from "../../components"
 import { write } from "./helpers"
+import DepGraph from "../../depgraph"
 
 export const FolderPage: QuartzEmitterPlugin<FullPageLayout> = (userOpts) => {
   const opts: FullPageLayout = {
@@ -35,6 +36,13 @@ export const FolderPage: QuartzEmitterPlugin<FullPageLayout> = (userOpts) => {
     name: "FolderPage",
     getQuartzComponents() {
       return [Head, Header, Body, ...header, ...beforeBody, pageBody, ...left, ...right, Footer]
+    },
+    async getDependencyGraph(ctx, content, _resources) {
+      // Example graph:
+      // nested/file.md --> nested/file.html
+      //          \-------> nested/index.html
+      // TODO implement
+      return new DepGraph()
     },
     async emit(ctx, content, resources): Promise<FilePath[]> {
       const fps: FilePath[] = []

--- a/quartz/plugins/emitters/static.ts
+++ b/quartz/plugins/emitters/static.ts
@@ -2,11 +2,23 @@ import { FilePath, QUARTZ, joinSegments } from "../../util/path"
 import { QuartzEmitterPlugin } from "../types"
 import fs from "fs"
 import { glob } from "../../util/glob"
+import DepGraph from "../../depgraph"
 
 export const Static: QuartzEmitterPlugin = () => ({
   name: "Static",
   getQuartzComponents() {
     return []
+  },
+  async getDependencyGraph({ argv, cfg }, _content, _resources) {
+    const graph = new DepGraph()
+
+    const staticPath = joinSegments(QUARTZ, "static")
+    const fps = await glob("**", staticPath, cfg.configuration.ignorePatterns)
+    for (const fp of fps) {
+      graph.addEdge(joinSegments("static", fp), joinSegments(argv.output, "static", fp) as FilePath)
+    }
+
+    return graph
   },
   async emit({ argv, cfg }, _content, _resources): Promise<FilePath[]> {
     const staticPath = joinSegments(QUARTZ, "static")

--- a/quartz/plugins/emitters/tagPage.tsx
+++ b/quartz/plugins/emitters/tagPage.tsx
@@ -15,6 +15,7 @@ import {
 import { defaultListPageLayout, sharedPageComponents } from "../../../quartz.layout"
 import { TagContent } from "../../components"
 import { write } from "./helpers"
+import DepGraph from "../../depgraph"
 
 export const TagPage: QuartzEmitterPlugin<FullPageLayout> = (userOpts) => {
   const opts: FullPageLayout = {
@@ -32,6 +33,10 @@ export const TagPage: QuartzEmitterPlugin<FullPageLayout> = (userOpts) => {
     name: "TagPage",
     getQuartzComponents() {
       return [Head, Header, Body, ...header, ...beforeBody, pageBody, ...left, ...right, Footer]
+    },
+    async getDependencyGraph(ctx, _content, _resources) {
+      // TODO implement
+      return new DepGraph()
     },
     async emit(ctx, content, resources): Promise<FilePath[]> {
       const fps: FilePath[] = []

--- a/quartz/plugins/types.ts
+++ b/quartz/plugins/types.ts
@@ -4,6 +4,7 @@ import { ProcessedContent } from "./vfile"
 import { QuartzComponent } from "../components/types"
 import { FilePath, FullSlug } from "../util/path"
 import { BuildCtx } from "../util/ctx"
+import DepGraph from "../depgraph"
 
 export interface PluginTypes {
   transformers: QuartzTransformerPluginInstance[]
@@ -38,4 +39,9 @@ export type QuartzEmitterPluginInstance = {
   name: string
   emit(ctx: BuildCtx, content: ProcessedContent[], resources: StaticResources): Promise<FilePath[]>
   getQuartzComponents(ctx: BuildCtx): QuartzComponent[]
+  getDependencyGraph(
+    ctx: BuildCtx,
+    content: ProcessedContent[],
+    resources: StaticResources,
+  ): Promise<DepGraph>
 }

--- a/quartz/util/ctx.ts
+++ b/quartz/util/ctx.ts
@@ -6,6 +6,7 @@ export interface Argv {
   verbose: boolean
   output: string
   serve: boolean
+  fastRebuild: boolean
   port: number
   wsPort: number
   remoteDevHost?: string


### PR DESCRIPTION
**Not intended for merge**.

This is the benchmarking code I used for measuring the improvements for https://github.com/kabirgh/quartz/pull/4.

## Results
**Summary: 98% reduction in build times, ~50x improvement, saving 2.5 seconds on average.**

I ran ~20 iterations of a test to verify performance improvements on my local machine (see this PR for benchmarking setup). The test consisted of editing the last line of a markdown file, saving it, and measuring the rebuild function's execution time. I've plotted the results below.

![benchmark_plot](https://github.com/kabirgh/quartz/assets/15871468/0ba989e5-1226-4756-8cf1-5ae94116a8cd)

Mean time for full rebuilds: 2548 ms.
Mean time for partial rebuilds: 47 ms.

Here are the individual charts. 
Full rebuilds, including 1st build:
![full_benchmark_plot](https://github.com/kabirgh/quartz/assets/15871468/309e3b9c-5fbd-4c8f-ace4-523cdd87a048)

Partial rebuilds, omitting 1st build:
![partial_benchmark_plot](https://github.com/kabirgh/quartz/assets/15871468/054720eb-5c1b-40cb-9292-b5619a15d19a)